### PR TITLE
added word wrap to chat.css to prevent scrollbars when posting a long…

### DIFF
--- a/htdocs/designs/official/Revolution/chat.css
+++ b/htdocs/designs/official/Revolution/chat.css
@@ -19,6 +19,7 @@ input,select	{
 	left:0;
 	right:0;
 	bottom:40px;
+	word-wrap: break-word;
 }
 
 div.chatmsg, div.serverMessage {


### PR DESCRIPTION
minor change in the css file that prevents scrollbars from happening when posting a long, nonspaced text in chat.