### PR TITLE
fixed background images for large desktops

### DIFF
--- a/htdocs/designs/official/Discovery/images/style.css
+++ b/htdocs/designs/official/Discovery/images/style.css
@@ -3,6 +3,8 @@ body {
 	background-repeat: no-repeat;
 	background-attachment: fixed;
 	background-position: left top;
+	background-size: contain;
+	background-color: black;
 	color: white;
 	margin:20px;
 	font-family:verdana, sans-serif, arial;
@@ -10,7 +12,7 @@ body {
 }
 
 /*
-Fix f�r PNG-Files
+Fix for PNG-Files
 img, div { behavior: url(scripts/iepngfix.htc) }
 */
 

--- a/htdocs/designs/official/Discovery/style.css
+++ b/htdocs/designs/official/Discovery/style.css
@@ -9,6 +9,8 @@ body {
 	background-repeat: no-repeat;
 	background-attachment: fixed;
 	background-position: left top;
+	background-size: contain;
+	background-color: black;
 	color: white;
 	margin:0px;
 	font-family:verdana, sans-serif, arial;

--- a/htdocs/designs/official/Graphite/style.css
+++ b/htdocs/designs/official/Graphite/style.css
@@ -11,7 +11,7 @@ body,html	{
 }
 
 body {
-	background:#000 url('images/mainbg.jpg') repeat;
+	background: #000 url('images/mainbg.jpg') round;
 	color: white;
 	font-family:verdana, sans-serif, arial;
 	font-size: 10pt;

--- a/htdocs/designs/official/Revolution/style.css
+++ b/htdocs/designs/official/Revolution/style.css
@@ -24,7 +24,8 @@
 }
 
 body {
-	background: url(./images/bg.jpg);
+	background: black url(./images/bg.jpg) no-repeat;
+	background-size: contain;
 	text-align: center;
 	color: #dae9ff;
 	font-family:verdana, sans-serif, arial;


### PR DESCRIPTION
nur kleine css anpassungen, im standard-design geht der background jetzt nach ganz unten, beim discovery ebenfalls. beim graphite sieht es besser aus wenn repeat auf round gesetzt ist (da sterne rundherum sind) und so nicht 2 galaxien erscheinen.