### PR TITLE
discord url instead of teamspeak

### DIFF
--- a/htdocs/inc/const.inc.php
+++ b/htdocs/inc/const.inc.php
@@ -145,7 +145,7 @@
 	define('CHAT_ONCLICK', "parent.top.location='chatframe.php';");
 
 	// Teamspeak
-	define('TEAMSPEAK_URL', "http://ts.etoa.ch");
+	define('TEAMSPEAK_URL', "https://discord.gg/7d2ndEU");
 	define('TEAMSPEAK_ONCLICK', "window.open('".TEAMSPEAK_URL."','ts','width=800,height=600,scrollbars=yes');");
 
 	// Game-Rules

--- a/htdocs/inc/const.inc.php
+++ b/htdocs/inc/const.inc.php
@@ -146,7 +146,7 @@
 
 	// Teamspeak
 	define('TEAMSPEAK_URL', "https://discord.gg/7d2ndEU");
-	define('TEAMSPEAK_ONCLICK', "window.open('".TEAMSPEAK_URL."','ts','width=800,height=600,scrollbars=yes');");
+	define('TEAMSPEAK_ONCLICK', "window.open('".TEAMSPEAK_URL."','_blank');");
 
 	// Game-Rules
 	define('RULES_URL', 'http://www.etoa.ch/regeln');


### PR DESCRIPTION
es wird immernoch "teamspeak" dargestellt, da die Bilder verändert werden müssten. 
Falls irgendwer sich mit Bild-manipulation auskennt oder die zusammenhängenden originalbilder mit original-schrift noch irgendwo hat darf er das gerne anpassen :)

anzupassen die bilder im ordner `htdocs/designs/official/Discovery/images` welche teamspeak im namen haben.