### PR TITLE
Available pilots always greater or equals zero

### DIFF
--- a/htdocs/classes/fleetlaunch.class.php
+++ b/htdocs/classes/fleetlaunch.class.php
@@ -181,7 +181,7 @@
 					if ($this->possibleFleetStarts > 0)
 					{
 						// Piloten
-						$this->pilotsAvailable = floor($this->sourceEntity->people() - $bl->totalPeopleWorking());
+						$this->pilotsAvailable = max(0,floor($this->sourceEntity->people() - $bl->totalPeopleWorking()));
 
 						$this->havenOk = true;
 					}


### PR DESCRIPTION
Allows start of zero pilot ships althought more people are employed than available (no negativ number for pilots, Issue #215).