### PR TITLE
Ally ships requirements in help

### DIFF
--- a/htdocs/admin/inc/xajax/global.xajax.php
+++ b/htdocs/admin/inc/xajax/global.xajax.php
@@ -1465,7 +1465,7 @@ function reqInfo($id,$cat='b')
 		$req_tbl = "tech_requirements";
 		$req_field = "obj_id";
 	}
-	elseif($cat=='s')
+	elseif($cat=='s' || $cat == 'sa')
 	{
 		$req_tbl = "ship_requirements";
 		$req_field = "obj_id";
@@ -1532,7 +1532,7 @@ function reqInfo($id,$cat='b')
 		$img = IMAGE_PATH."/technologies/technology".$id."_middle.".IMAGE_EXT;
 		$name = $te_name[$id];
 	}
-	elseif($cat=='s')
+	elseif($cat=='s' || $cat == 'sa')
 	{
 		$img = IMAGE_PATH."/ships/ship".$id."_middle.".IMAGE_EXT;
 		$name = $sh_name[$id];

--- a/htdocs/content/help.php
+++ b/htdocs/content/help.php
@@ -33,16 +33,12 @@
 	if (isset($_GET['site']) && ctype_alsc($_GET['site']) && $_GET['site']!="")
 	{
 		$site = $_GET['site'];
-		if ($site!="")
+		if (file_exists(RELATIVE_ROOT . "info/$site.php")) {
+			include(RELATIVE_ROOT . "info/$site.php");
+		}
+		else
 		{
-			if (file_exists(RELATIVE_ROOT."info/$site.php"))
-			{
-				include (RELATIVE_ROOT."info/$site.php");
-			}
-			else
-			{
-				error_msg("Hilfedatei nicht gefunden!");
-			}
+			error_msg("Hilfedatei nicht gefunden!");
 		}
 		return_btn();
 	}

--- a/htdocs/inc/xajax/techtree.xajax.php
+++ b/htdocs/inc/xajax/techtree.xajax.php
@@ -54,7 +54,7 @@ function reqInfo($id,$cat='b')
 		$req_tbl = "tech_requirements";
 		$req_field = "obj_id";
 	}
-	elseif($cat=='s')
+	elseif($cat=='s' || $cat=='sa')
 	{
 		$req_tbl = "ship_requirements";
 		$req_field = "obj_id";
@@ -90,6 +90,29 @@ function reqInfo($id,$cat='b')
 		}
 	}
 	
+	// Alliance ships are not in requirements tables. The required level of the Alliance shipyard is given directly in the ship details.
+	if ($cat == "sa")
+	{
+		$res = dbquery("SELECT ship_alliance_shipyard_level FROM ships WHERE ship_id = " . $id . " AND ship_alliance_shipyard_level > 0;");
+		$nr3 = mysql_num_rows($res);
+		if ($nr3 > 0)
+		{
+			while ($arr = mysql_fetch_assoc($res))
+			{
+				$allyShipyardId = 3;
+				$res2 = dbquery("SELECT alliance_building_name FROM alliance_buildings WHERE alliance_building_id = " . $allyShipyardId . ";");
+				$nr4 = mysql_num_rows($res2);
+				if ($nr4 > 0)
+				{
+					while ($arr2 = mysql_fetch_assoc($res2))
+					{
+						$items[] = array($allyShipyardId, $arr2['alliance_building_name'], $arr['ship_alliance_shipyard_level'], IMAGE_PATH . "/abuildings/building" . $allyShipyardId . "_middle." . IMAGE_EXT, "");
+					}
+				}
+			}
+		}
+	}
+	
 	if (count($items)>0)
 	{
 		echo "<div class=\"techtreeItemContainer\">";
@@ -121,7 +144,7 @@ function reqInfo($id,$cat='b')
 		$img = IMAGE_PATH."/technologies/technology".$id."_middle.".IMAGE_EXT;
 		$name = $te_name[$id];
 	}
-	elseif($cat=='s')
+	elseif($cat=='s' || $cat=='sa')
 	{
 		$img = IMAGE_PATH."/ships/ship".$id."_middle.".IMAGE_EXT;
 		$name = $sh_name[$id];

--- a/htdocs/inc/xajax/techtree.xajax.php
+++ b/htdocs/inc/xajax/techtree.xajax.php
@@ -11,33 +11,33 @@ function reqInfo($id,$cat='b')
 
 
 	// Load items
-	$bures = dbquery("SELECT building_id,building_name FROM buildings WHERE building_show=1;");
-	while ($buarr = mysql_fetch_array($bures))
+	$res = dbquery("SELECT building_id,building_name FROM buildings WHERE building_show=1;");
+	while ($arr = mysql_fetch_array($res))
 	{
-		$bu_name[$buarr['building_id']]=$buarr['building_name'];
+		$bu_name[$arr['building_id']]=$arr['building_name'];
 	}		
-	$teres = dbquery("SELECT tech_id,tech_name FROM technologies WHERE tech_show=1;");
-	while ($tearr = mysql_fetch_array($teres))
+	$res = dbquery("SELECT tech_id,tech_name FROM technologies WHERE tech_show=1;");
+	while ($arr = mysql_fetch_array($res))
 	{
-		$te_name[$tearr['tech_id']]=$tearr['tech_name'];
+		$te_name[$arr['tech_id']]=$arr['tech_name'];
 	}	
 
-	$teres = dbquery("SELECT ship_id,ship_name FROM ships WHERE ship_show=1 AND special_ship=0;");
-	while ($tearr = mysql_fetch_array($teres))
+	$res = dbquery("SELECT ship_id,ship_name FROM ships WHERE ship_show=1 AND special_ship=0;");
+	while ($arr = mysql_fetch_array($res))
 	{
-		$sh_name[$tearr['ship_id']]=$tearr['ship_name'];
+		$sh_name[$arr['ship_id']]=$arr['ship_name'];
 	}	
 	
-	$teres = dbquery("SELECT def_id,def_name FROM defense WHERE def_show=1;");
-	while ($tearr = mysql_fetch_array($teres))
+	$res = dbquery("SELECT def_id,def_name FROM defense WHERE def_show=1;");
+	while ($arr = mysql_fetch_array($res))
 	{
-		$de_name[$tearr['def_id']]=$tearr['def_name'];
+		$de_name[$arr['def_id']]=$arr['def_name'];
 	}		
 	
-	$teres = dbquery("SELECT missile_id,missile_name FROM missiles WHERE missile_show=1;");
-	while ($tearr = mysql_fetch_array($teres))
+	$res = dbquery("SELECT missile_id,missile_name FROM missiles WHERE missile_show=1;");
+	while ($arr = mysql_fetch_array($res))
 	{
-		$m_name[$tearr['missile_id']]=$tearr['missile_name'];
+		$m_name[$arr['missile_id']]=$arr['missile_name'];
 	}		
 	
 	//
@@ -72,8 +72,7 @@ function reqInfo($id,$cat='b')
 	
 	$items = array();
 	$res = dbquery("SELECT * FROM $req_tbl WHERE obj_id=".$id." AND req_building_id>0 AND req_level>0 ORDER BY req_level;");
-	$nr = mysql_num_rows($res);
-	if ($nr>0)
+	if (mysql_num_rows($res)>0)
 	{
 		while($arr=mysql_fetch_assoc($res))
 		{
@@ -81,8 +80,7 @@ function reqInfo($id,$cat='b')
 		}
 	}
 	$res = dbquery("SELECT * FROM $req_tbl WHERE $req_field=".$id." AND req_tech_id>0 AND req_level>0 ORDER BY req_level;");
-	$nr2 = mysql_num_rows($res);
-	if ($nr2>0)
+	if (mysql_num_rows($res)>0)
 	{
 		while($arr=mysql_fetch_assoc($res))
 		{
@@ -90,25 +88,17 @@ function reqInfo($id,$cat='b')
 		}
 	}
 	
-	// Alliance ships are not in requirements tables. The required level of the Alliance shipyard is given directly in the ship details.
-	if ($cat == "sa")
+	// Alliance ships are not in requirements tables. The required level of the alliance shipyard is given directly in the ship details.
+	if ($cat=="sa")
 	{
-		$res = dbquery("SELECT ship_alliance_shipyard_level FROM ships WHERE ship_id = " . $id . " AND ship_alliance_shipyard_level > 0;");
-		$nr3 = mysql_num_rows($res);
-		if ($nr3 > 0)
+		$res = dbquery("SELECT ship_alliance_shipyard_level FROM ships WHERE ship_id=".$id." AND ship_alliance_shipyard_level>0;");
+		if (mysql_num_rows($res)==1 && $ship = mysql_fetch_assoc($res))
 		{
-			while ($arr = mysql_fetch_assoc($res))
+			$allianceBuildingId_shipyard = 3;
+			$res = dbquery("SELECT alliance_building_name FROM alliance_buildings WHERE alliance_building_id=".$allianceBuildingId_shipyard.";");
+			if (mysql_num_rows($res)==1 && $allianceBuilding = mysql_fetch_assoc($res))
 			{
-				$allyShipyardId = 3;
-				$res2 = dbquery("SELECT alliance_building_name FROM alliance_buildings WHERE alliance_building_id = " . $allyShipyardId . ";");
-				$nr4 = mysql_num_rows($res2);
-				if ($nr4 > 0)
-				{
-					while ($arr2 = mysql_fetch_assoc($res2))
-					{
-						$items[] = array($allyShipyardId, $arr2['alliance_building_name'], $arr['ship_alliance_shipyard_level'], IMAGE_PATH . "/abuildings/building" . $allyShipyardId . "_middle." . IMAGE_EXT, "");
-					}
-				}
+				$items[] = array($allianceBuildingId_shipyard, $allianceBuilding['alliance_building_name'], $ship['ship_alliance_shipyard_level'], IMAGE_PATH."/abuildings/building".$allianceBuildingId_shipyard."_middle.".IMAGE_EXT, "");
 			}
 		}
 	}

--- a/htdocs/info/shipyard.php
+++ b/htdocs/info/shipyard.php
@@ -257,8 +257,8 @@
 			</div>";
 			$shipCatId = $arr['ship_cat_id'];
 			$shipCatIdAlliance = 6;
-			$shipCategoryAbbr = $shipCatId == $shipCatIdAlliance ? "sa" : "s";
-			echo '<script type="text/javascript">xajax_reqInfo('.$arr['ship_id'].',"'. $shipCategoryAbbr.'")</script>';
+			$shipCatAbbr = $shipCatId == $shipCatIdAlliance ? "sa" : "s";
+			echo '<script type="text/javascript">xajax_reqInfo('.$arr['ship_id'].',"'. $shipCatAbbr.'")</script>';
 			echo "</td></tr>";	
 		
 	    tableEnd();

--- a/htdocs/info/shipyard.php
+++ b/htdocs/info/shipyard.php
@@ -254,8 +254,11 @@
 			echo "<tr><td class=\"tbldata\" colspan=\"4\" style=\"text-align:center\">";
 			echo "<div id=\"reqInfo\" style=\"width:100%;\">
 			<br/><div class=\"loadingMsg\">Bitte warten...</div>
-			</div>";	
-			echo '<script type="text/javascript">xajax_reqInfo('.$arr['ship_id'].',"s")</script>';
+			</div>";
+			$shipCatId = $arr['ship_cat_id'];
+			$shipCatIdAlliance = 6;
+			$shipCategoryAbbr = $shipCatId == $shipCatIdAlliance ? "sa" : "s";
+			echo '<script type="text/javascript">xajax_reqInfo('.$arr['ship_id'].',"'. $shipCategoryAbbr.'")</script>';
 			echo "</td></tr>";	
 		
 	    tableEnd();


### PR DESCRIPTION
Eigentlich wäre es sauberer, das Feld ship_alliance_shipyard_level aus der Tabelle ships zu löschen und eine neue Tabelle alliance_building_requirements zu erstellen. Da ich aber nicht weiss, wie weit ship_alliance_shipyard_level verwendet wird, habe ich es direkt im php geflickt.