### PR TITLE
Weiter zum Urknall button works now

### DIFF
--- a/templates/admin/overview/overview.html.twig
+++ b/templates/admin/overview/overview.html.twig
@@ -85,7 +85,7 @@
     {% if not didBigBangHappen %}
         {{ macros.messagebox('Das Universum wurde noch nicht erschaffen!', 'warning', 'Universum existiert noch nicht!')}}
         <p>
-            <input type="button" value="Weiter zum Urknall" onclick="document.location='../?page=galaxy&sub=uni'" />
+            <input type="button" value="Weiter zum Urknall" onclick="document.location='/admin/?page=galaxy&sub=uni'" />
         </p>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Admin overview button had wrong URL.

### DRAFT
The underlying problem is having a mix between path and query URLs for pages, eg `/admin/overview/` and `/admin/?page=overview`.

In this merge request, the fix is to change the link url of the button from `?page=galaxy&sub=uni` to `../?page=galaxy&sub=uni`. The `..` part strips the `/overview/`.

However, ideally changes to the `?page` get query parameter should automatically change the URL path. Or, even better, everything is converted to path-style URLs or query-style URLs only.