### PR TITLE
Buildlist: add foreign key on buildings to avoid having invalid building ids stored

### DIFF
--- a/db/migrations/0036-20220410-buidlist_unique_key.sql
+++ b/db/migrations/0036-20220410-buidlist_unique_key.sql
@@ -1,0 +1,6 @@
+ALTER TABLE buildlist ENGINE=InnoDB;
+DELETE FROM buildlist WHERE buildlist_building_id NOT IN (
+    SELECT building_id FROM buildings
+);
+
+ALTER TABLE buildlist ADD CONSTRAINT fk_building_id FOREIGN KEY (buildlist_building_id) REFERENCES buildings(building_id);


### PR DESCRIPTION
Fixes https://github.com/etoa/etoa-gui/issues/505
Caused by issues solved in https://github.com/etoa/etoa-gui/pull/503