### PR TITLE
fixes #525 using explicit default return value on nonexistent key

### DIFF
--- a/eventhandler/src/config/ConfigHandler.cpp
+++ b/eventhandler/src/config/ConfigHandler.cpp
@@ -6,6 +6,11 @@
 	std::string Config::get(std::string name, int value)
 	{
 		std::vector<std::string> temp (3);
+		// return empty string as default value if no such key exists
+		if(0 == sConfig.count(name))
+		{
+			return("");
+		}
 		temp = cConfig.at(sConfig[name]);
 		return(temp[value]);
 	}


### PR DESCRIPTION
underlying issue of existence assumptions for config values still exists, might lead to more unexpected behaviour in the future (but no more sql errors for now)