### PR TITLE
fixed: if planet is unnamed, page titles look incomplete

### DIFF
--- a/htdocs/content/buildings.php
+++ b/htdocs/content/buildings.php
@@ -54,7 +54,7 @@ if ($properties->imageFilter) {
 if (isset($cp)) {
     $planet = $planetRepo->find($cp->id);
 
-    echo "<h1>Bauhof des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Bauhof" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
 
     echo $resourceBoxDrawer->getHTML($planet);
 

--- a/htdocs/content/bunker.php
+++ b/htdocs/content/bunker.php
@@ -31,7 +31,7 @@ $request = Request::createFromGlobals();
 if ($cp) {
     $planet = $planetRepo->find($cp->id);
 
-    echo "<h1>Bunker des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Bunker" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
 
     echo $resourceBoxDrawer->getHTML($planet);
 

--- a/htdocs/content/crypto.php
+++ b/htdocs/content/crypto.php
@@ -184,13 +184,13 @@ if ($config->getBoolean('crypto_enable')) {
             countDown("cdcd", $userCooldown);
         }
     } else {
-        echo "<h1>Kryptocenter des Planeten " . $planet->name . "</h1>";
+        echo "<h1>Kryptocenter" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
         echo $resourceBoxDrawer->getHTML($planet);
 
         info_msg("Das Kryptocenter wurde noch nicht gebaut!");
     }
 } else {
-    echo "<h1>Kryptocenter des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Kryptocenter" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
     echo $resourceBoxDrawer->getHTML($planet);
 
     info_msg("Aufgrund eines intergalaktischen Moratoriums der Völkerföderation der Galaxie Andromeda

--- a/htdocs/content/defense.php
+++ b/htdocs/content/defense.php
@@ -94,7 +94,7 @@ if ($factoryBuilding !== null && $factoryBuilding->currentLevel > 0) {
     $peopleWorking = $buildingRepository->getPeopleWorking($planet->id);
 
     // Titel
-    echo "<h1>Waffenfabrik (Stufe " . $factoryBuilding->currentLevel . ") des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Waffenfabrik (Stufe " . $factoryBuilding->currentLevel . ")" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
 
     // Ressourcen anzeigen
     echo $resourceBoxDrawer->getHTML($planet);
@@ -1055,7 +1055,7 @@ if ($factoryBuilding !== null && $factoryBuilding->currentLevel > 0) {
     }
 } else {
     // Titel
-    echo "<h1>Waffenfabrik des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Waffenfabrik" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
 
     // Ressourcen anzeigen
     echo $resourceBoxDrawer->getHTML($planet);

--- a/htdocs/content/economy.php
+++ b/htdocs/content/economy.php
@@ -72,7 +72,7 @@ if ($cp) {
         }
     }
 
-    echo "<h1>Wirtschaft des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Wirtschaft" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
     echo $resourceBoxDrawer->getHTML($planet);
 
     if (isset($_GET['action']) && $_GET['action'] == "update") {

--- a/htdocs/content/haven.php
+++ b/htdocs/content/haven.php
@@ -33,7 +33,7 @@ $shipDataRepository = $app[ShipDataRepository::class];
 if ($cp) {
     $planet = $planetRepo->find($cp->id);
 
-    echo '<h1>Raumschiffhafen des Planeten ' . $planet->name . '</h1>';
+    echo "<h1>Raumschiffhafen" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
     echo $resourceBoxDrawer->getHTML($planet);
 
     if (!$cu->isVerified) {

--- a/htdocs/content/market.php
+++ b/htdocs/content/market.php
@@ -72,7 +72,7 @@ if ($config->getBoolean('market_enabled')) {
         define("MARKET_TAX", max(1, MARKET_SELL_TAX * ($specialist !== null ? $specialist->tradeBonus : 1)));
 
         // Show title
-        echo '<h1>Marktplatz (Stufe ' . $market->currentLevel . ') des Planeten ' . $planet->name . '</h1>';
+        echo "<h1>Marktplatz (Stufe " . $market->currentLevel . ")" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
         echo $resourceBoxDrawer->getHTML($planet);
 
         if (!$market->isDeactivated()) {

--- a/htdocs/content/missiles.php
+++ b/htdocs/content/missiles.php
@@ -71,7 +71,7 @@ if ($missileBuilding !== null && $missileBuilding->currentLevel > 0) {
     $max_flights = $missileBuilding->currentLevel * MISSILE_SILO_FLIGHTS_PER_LEVEL;
 
     // Titel
-    echo "<h1>Raketensilo (Stufe " . $missileBuilding->currentLevel . ") des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Raketensilo (Stufe " . $missileBuilding->currentLevel . ")" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
 
     // Ressourcen anzeigen
     echo $resourceBoxDrawer->getHTML($planet);
@@ -733,7 +733,7 @@ if ($missileBuilding !== null && $missileBuilding->currentLevel > 0) {
     }
 } else {
     // Titel
-    echo "<h1>Raketensilo des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Raketensilo" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
 
     // Ressourcen anzeigen
     echo $resourceBoxDrawer->getHTML($planet);

--- a/htdocs/content/population.php
+++ b/htdocs/content/population.php
@@ -36,7 +36,7 @@ $technologyRequirementRepository = $app[TechnologyRequirementRepository::class];
 if ($cp) {
     $planet = $planetRepo->find($cp->id);
 
-    echo '<h1>Bevölkerungsübersicht des Planeten ' . $planet->name . '</h1>';
+    echo "<h1>Bevölkerungsübersicht" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
     echo '<div id="population_info"></div>'; // Nur zu testzwecken
     echo $resourceBoxDrawer->getHTML($planet);
 

--- a/htdocs/content/recycle.php
+++ b/htdocs/content/recycle.php
@@ -44,7 +44,7 @@ define("RECYC_MAX_PAYBACK", $config->getFloat('recyc_max_payback'));
 
 $planet = $planetRepo->find($cp->id);
 
-echo "<h1>Recyclingstation des Planeten " . $planet->name . "</h1>";
+echo "<h1>Recyclingstation" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
 echo $resourceBoxDrawer->getHTML($planet);
 
 //Recycling Level laden

--- a/htdocs/content/research.php
+++ b/htdocs/content/research.php
@@ -67,7 +67,7 @@ if (isset($cp)) {
         $minBuildTimeFactor = (0.1 - (GEN_TECH_LEVEL / 100));
 
         // Überschrift
-        echo "<h1>Forschungslabor (Stufe " . $researchBuilding->currentLevel . ") des Planeten " . $planet->name . "</h1>";
+        echo "<h1>Forschungslabor (Stufe " . $researchBuilding->currentLevel . ")" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
         echo $resourceBoxDrawer->getHTML($planet);
 
         // Forschungsliste laden && Gentech level definieren
@@ -922,7 +922,7 @@ if (isset($cp)) {
             }
         }
     } else {
-        echo "<h1>Forschungslabor des Planeten " . $planet->name . "</h1>";
+        echo "<h1>Forschungslabor" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
         echo $resourceBoxDrawer->getHTML($planet);
         info_msg("Das Forschungslabor wurde noch nicht gebaut!");
     }

--- a/htdocs/content/shipyard.php
+++ b/htdocs/content/shipyard.php
@@ -1085,7 +1085,7 @@ if ($shipyard !== null && $shipyard->currentLevel > 0) {
     }
 } else {
     // Titel
-    echo "<h1>Raumschiffswerft des Planeten " . $planet->name . "</h1>";
+    echo "<h1>Raumschiffswerft" . ($planet->name ? " des Planeten " . $planet->name : "") . "</h1>";
 
     // Ressourcen anzeigen
     echo $resourceBoxDrawer->getHTML($planet);

--- a/htdocs/content/techtree.php
+++ b/htdocs/content/techtree.php
@@ -137,7 +137,7 @@ if ($mode == "tech") {
 if (isset($cp)) {
 
     // Daten anzeigen
-    echo "<h1>Technikbaum des Planeten " . $cp->name() . "</h1>";
+    echo "<h1>Technikbaum" . ($cp->name() ? " des Planeten " . $cp->name() : "") . "</h1>";
 
     // Tab-Navigation anzeigen
     show_tab_menu("mode", array(


### PR DESCRIPTION
like 'Bauhof des Planeten ' (without any name after).

This improvement shows the 2nd part only if the name is of nonzero length.