### PR TITLE
fixed specialists page sql query error: ERROR 1140 (42000)…

### DIFF
--- a/src/User/UserRepository.php
+++ b/src/User/UserRepository.php
@@ -154,6 +154,7 @@ class UserRepository extends AbstractRepository
     }
 
     /**
+     * associative array: for each specialist (id), get number of users which have this specialist active (count)
      * @return array<int, int>
      */
     public function countUsersWithSpecialists(): array
@@ -162,6 +163,7 @@ class UserRepository extends AbstractRepository
             ->select('user_specialist_id, COUNT(user_id)')
             ->from('users')
             ->where('user_specialist_time > :now')
+            ->groupBy('user_specialist_id')
             ->setParameters([
                 'now' => time(),
             ])


### PR DESCRIPTION
> In aggregated query without GROUP BY, expression #1 of SELECT list contains nonaggregated column (...)

error gets thrown when opening specialist page normally.

fix: improved query by adding group by for what is assumed to be the intended operation of the `countUsersWithSpecialists()` function